### PR TITLE
Explicitly re-export all the names in __init__

### DIFF
--- a/newsfragments/14.misc.rst
+++ b/newsfragments/14.misc.rst
@@ -1,0 +1,3 @@
+tricycle now explicitly re-exports all names, improving PEP-561 compliance and
+allowing type checkers that enforce export strictness (including mypy with
+``--no-implicit-reexport``) to check code using tricycle

--- a/tricycle/__init__.py
+++ b/tricycle/__init__.py
@@ -1,10 +1,13 @@
 from ._version import __version__
 
-from ._rwlock import RWLock
-from ._streams import BufferedReceiveStream, TextReceiveStream
-from ._multi_cancel import MultiCancelScope
-from ._service_nursery import open_service_nursery
-from ._meta import ScopedObject, BackgroundObject
+from ._rwlock import RWLock as RWLock
+from ._streams import (
+    BufferedReceiveStream as BufferedReceiveStream,
+    TextReceiveStream as TextReceiveStream,
+)
+from ._multi_cancel import MultiCancelScope as MultiCancelScope
+from ._service_nursery import open_service_nursery as open_service_nursery
+from ._meta import ScopedObject as ScopedObject, BackgroundObject as BackgroundObject
 
 # watch this space...
 


### PR DESCRIPTION
mypy is pretty strict about "if you say py.typed, you better mean it,"
including re-export requirements.

I was running some external code that uses tricycle with `mypy
--strict`, and it was complaining that the names in tricycle weren't
found (when trying to reference them like `import tricycle;
tricycle.Foo`) and then that they weren't explicitly
re-exported (when referencing them as `from tricycle import Foo`)

With this change, there are no complaints!