### PR TITLE
Add TreeVar

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ exclude_lines =
   pragma: no cover
   abc.abstractmethod
   if TYPE_CHECKING:
+  @overload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
         env:
           # Should match 'name:' up above
           JOB_NAME: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
+      - uses: codecov/codecov-action@v3
+        with:
+          directory: empty
+          name: 'Windows (${{ matrix.python }}, ${{ matrix.arch }})'
+          flags: Windows,${{ matrix.python }}
 
   Ubuntu:
     name: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
@@ -85,6 +90,11 @@ jobs:
           CHECK_LINT: '${{ matrix.check_lint }}'
           # Should match 'name:' up above
           JOB_NAME: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
+      - uses: codecov/codecov-action@v3
+        with:
+          directory: empty
+          name: 'Ubuntu (${{ matrix.python }}${{ matrix.extra_name }})'
+          flags: Ubuntu,${{ matrix.python }}
 
   macOS:
     name: 'macOS (${{ matrix.python }})'
@@ -113,3 +123,8 @@ jobs:
         env:
           # Should match 'name:' up above
           JOB_NAME: 'macOS (${{ matrix.python }})'
+      - uses: codecov/codecov-action@v3
+        with:
+          directory: empty
+          name: 'macOS (${{ matrix.python }})'
+          flags: macOS,${{ matrix.python }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,18 @@
-# https://docs.readthedocs.io/en/latest/yaml-config.html
+# https://docs.readthedocs.io/en/latest/config-file/index.html
+version: 2
+
 formats:
   - htmlzip
   - epub
 
-requirements_file: docs-requirements.txt
-
-# Currently RTD's default image only has 3.5
-# This gets us 3.6 (and hopefully 3.7 in the future)
-# https://docs.readthedocs.io/en/latest/yaml-config.html#build-image
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 
 python:
-  version: 3.6
-  pip_install: True
+  install:
+    - requirements: docs-requirements.txt
+
+sphinx:
+  fail_on_warning: true

--- a/README.rst
+++ b/README.rst
@@ -5,13 +5,13 @@ tricycle: experimental extensions for Trio
    :target: https://pypi.org/project/tricycle
    :alt: Latest PyPI version
 
+.. image:: https://github.com/oremanj/tricycle/actions/workflows/ci.yml/badge.svg
+   :target: https://github.com/oremanj/tricycle/actions/workflows/ci.yml
+   :alt: Automated test status
+
 .. image:: https://img.shields.io/badge/docs-read%20now-blue.svg
    :target: https://tricycle.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation status
-
-.. image:: https://travis-ci.org/oremanj/tricycle.svg?branch=master
-   :target: https://travis-ci.org/oremanj/tricycle
-   :alt: Automated test status
 
 .. image:: https://codecov.io/gh/oremanj/tricycle/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/oremanj/tricycle

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,20 @@ import sys
 # So autodoc can import our package
 sys.path.insert(0, os.path.abspath('../..'))
 
+# https://docs.readthedocs.io/en/stable/builds.html#build-environment
+if "READTHEDOCS" in os.environ:
+    import glob
+
+    if glob.glob("../../newsfragments/*.*.rst"):
+        print("-- Found newsfragments; running towncrier --", flush=True)
+        import subprocess
+
+        subprocess.run(
+            ["towncrier", "--yes", "--date", "not released yet"],
+            cwd="../..",
+            check=True,
+        )
+
 # Warn about all references to unknown targets
 nitpicky = True
 # Except for these ones, which we expect to point to unknown targets:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,11 @@ nitpick_ignore = [
     ("py:obj", "bytes-like"),
     ("py:class", "None"),
     ("py:exc", "Anything else"),
+    ("py:class", "tricycle._rwlock._RWLockStatistics"),
+    ("py:class", "tricycle._tree_var.T"),
+    ("py:class", "tricycle._tree_var.U"),
 ]
+default_role = "obj"
 
 # -- General configuration ------------------------------------------------
 
@@ -104,7 +108,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -223,7 +223,7 @@ Tree variables
 
 When you start a new Trio task, the initial values of its `context variables
 <https://trio.readthedocs.io/en/stable/reference-core.html#task-local-storage>`__
-(`contextlib.ContextVar`) are inherited from the environment of the
+(`contextvars.ContextVar`) are inherited from the environment of the
 `~trio.Nursery.start_soon` or `~trio.Nursery.start` call that
 started the new task. For example, this code:
 

--- a/newsfragments/18.feature.rst
+++ b/newsfragments/18.feature.rst
@@ -1,0 +1,6 @@
+Added `tricycle.TreeVar`, which acts like a context variable that is
+inherited at nursery creation time (and then by child tasks of that
+nursery) rather than at task creation time. :ref:`Tree variables
+<tree-variables>` are useful for providing safe 'ambient' access to a
+resource that is tied to an `async with` block in the parent task,
+such as an open file or trio-asyncio event loop.

--- a/newsfragments/18.feature.rst
+++ b/newsfragments/18.feature.rst
@@ -2,5 +2,5 @@ Added `tricycle.TreeVar`, which acts like a context variable that is
 inherited at nursery creation time (and then by child tasks of that
 nursery) rather than at task creation time. :ref:`Tree variables
 <tree-variables>` are useful for providing safe 'ambient' access to a
-resource that is tied to an `async with` block in the parent task,
+resource that is tied to an ``async with`` block in the parent task,
 such as an open file or trio-asyncio event loop.

--- a/tricycle/__init__.py
+++ b/tricycle/__init__.py
@@ -8,6 +8,7 @@ from ._streams import (
 from ._multi_cancel import MultiCancelScope as MultiCancelScope
 from ._service_nursery import open_service_nursery as open_service_nursery
 from ._meta import ScopedObject as ScopedObject, BackgroundObject as BackgroundObject
+from ._tree_var import TreeVar as TreeVar, TreeVarToken as TreeVarToken
 
 # watch this space...
 

--- a/tricycle/_tests/test_tree_var.py
+++ b/tricycle/_tests/test_tree_var.py
@@ -66,7 +66,7 @@ def trivial_abort(_: object) -> trio.lowlevel.Abort:
     return trio.lowlevel.Abort.SUCCEEDED  # pragma: no cover
 
 
-async def test_treevar_follows_eventual_parent():
+async def test_treevar_follows_eventual_parent() -> None:
     tv1 = TreeVar[str]("tv1")
 
     async def manage_target(task_status: TaskStatus[trio.Nursery]) -> None:
@@ -106,7 +106,7 @@ async def test_treevar_token_bound_to_task_that_obtained_it() -> None:
     tv1 = TreeVar[int]("tv1")
     token: Optional[TreeVarToken[int]] = None
 
-    async def get_token():
+    async def get_token() -> None:
         nonlocal token
         token = tv1.set(10)
         try:
@@ -141,4 +141,4 @@ def test_treevar_outside_run() -> None:
         tv1.being(40).__enter__,
     ):
         with pytest.raises(RuntimeError, match="must be called from async context"):
-            operation()
+            operation()  # type: ignore

--- a/tricycle/_tests/test_tree_var.py
+++ b/tricycle/_tests/test_tree_var.py
@@ -1,0 +1,144 @@
+import pytest
+import trio
+import trio.testing
+from functools import partial
+from trio_typing import TaskStatus
+from typing import Optional, Any, cast
+
+from .. import TreeVar, TreeVarToken
+
+
+async def test_treevar() -> None:
+    tv1 = TreeVar[int]("tv1")
+    tv2 = TreeVar[Optional[int]]("tv2", default=None)
+    tv3 = TreeVar("tv3", default=-1)
+    assert tv1.name == "tv1"
+    assert "TreeVar name='tv2'" in repr(tv2)
+
+    with pytest.raises(LookupError):
+        tv1.get()
+    assert tv2.get() is None
+    assert tv1.get(42) == 42
+    assert tv2.get(42) == 42
+
+    NOTHING = cast(int, object())
+
+    async def should_be(val1: int, val2: int, new1: int = NOTHING) -> None:
+        assert tv1.get(NOTHING) == val1
+        assert tv2.get(NOTHING) == val2
+        if new1 is not NOTHING:
+            tv1.set(new1)
+
+    tok1 = tv1.set(10)
+    async with trio.open_nursery() as outer:
+        tok2 = tv1.set(15)
+        with tv2.being(20):
+            assert tv2.get_in(trio.lowlevel.current_task()) == 20
+            async with trio.open_nursery() as inner:
+                tv1.reset(tok2)
+                outer.start_soon(should_be, 10, NOTHING, 100)
+                inner.start_soon(should_be, 15, 20, 200)
+                await trio.testing.wait_all_tasks_blocked()
+                assert tv1.get_in(trio.lowlevel.current_task()) == 10
+                await should_be(10, 20, 300)
+                assert tv1.get_in(inner) == 15
+                assert tv1.get_in(outer) == 10
+                assert tv1.get_in(trio.lowlevel.current_task()) == 300
+                assert tv2.get_in(inner) == 20
+                assert tv2.get_in(outer) is None
+                assert tv2.get_in(trio.lowlevel.current_task()) == 20
+                tv1.reset(tok1)
+                await should_be(NOTHING, 20)
+                assert tv1.get_in(inner) == 15
+                assert tv1.get_in(outer) == 10
+                with pytest.raises(LookupError):
+                    assert tv1.get_in(trio.lowlevel.current_task())
+                # Test get_in() needing to search a parent task but
+                # finding no value there:
+                tv3 = TreeVar("tv3", default=-1)
+                assert tv3.get_in(outer) == -1
+                assert tv3.get_in(outer, -42) == -42
+        assert tv2.get() is None
+        assert tv2.get_in(trio.lowlevel.current_task()) is None
+
+
+def trivial_abort(_: object) -> trio.lowlevel.Abort:
+    return trio.lowlevel.Abort.SUCCEEDED  # pragma: no cover
+
+
+async def test_treevar_follows_eventual_parent():
+    tv1 = TreeVar[str]("tv1")
+
+    async def manage_target(task_status: TaskStatus[trio.Nursery]) -> None:
+        assert tv1.get() == "source nursery"
+        with tv1.being("target nursery"):
+            assert tv1.get() == "target nursery"
+            async with trio.open_nursery() as target_nursery:
+                with tv1.being("target nested child"):
+                    assert tv1.get() == "target nested child"
+                    task_status.started(target_nursery)
+                    await trio.lowlevel.wait_task_rescheduled(trivial_abort)
+                    assert tv1.get() == "target nested child"
+                assert tv1.get() == "target nursery"
+            assert tv1.get() == "target nursery"
+        assert tv1.get() == "source nursery"
+
+    async def verify(
+        value: str, *, task_status: TaskStatus[None] = trio.TASK_STATUS_IGNORED
+    ) -> None:
+        assert tv1.get() == value
+        task_status.started()
+        assert tv1.get() == value
+
+    with tv1.being("source nursery"):
+        async with trio.open_nursery() as source_nursery:
+            with tv1.being("source->target start call"):
+                target_nursery = await source_nursery.start(manage_target)
+            with tv1.being("verify task"):
+                source_nursery.start_soon(verify, "source nursery")
+                target_nursery.start_soon(verify, "target nursery")
+                await source_nursery.start(verify, "source nursery")
+                await target_nursery.start(verify, "target nursery")
+            trio.lowlevel.reschedule(target_nursery.parent_task)
+
+
+async def test_treevar_token_bound_to_task_that_obtained_it() -> None:
+    tv1 = TreeVar[int]("tv1")
+    token: Optional[TreeVarToken[int]] = None
+
+    async def get_token():
+        nonlocal token
+        token = tv1.set(10)
+        try:
+            await trio.lowlevel.wait_task_rescheduled(trivial_abort)
+        finally:
+            tv1.reset(token)
+            with pytest.raises(LookupError):
+                tv1.get()
+            with pytest.raises(LookupError):
+                tv1.get_in(trio.lowlevel.current_task())
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(get_token)
+        await trio.testing.wait_all_tasks_blocked()
+        assert token is not None
+        with pytest.raises(ValueError, match="different Context"):
+            tv1.reset(token)
+        assert tv1.get_in(list(nursery.child_tasks)[0]) == 10
+        nursery.cancel_scope.cancel()
+
+
+def test_treevar_outside_run() -> None:
+    async def run_sync(fn: Any, *args: Any) -> Any:
+        return fn(*args)
+
+    tv1 = TreeVar("tv1", default=10)
+    for operation in (
+        tv1.get,
+        partial(tv1.get, 20),
+        partial(tv1.set, 30),
+        lambda: tv1.reset(trio.run(run_sync, tv1.set, 10)),
+        tv1.being(40).__enter__,
+    ):
+        with pytest.raises(RuntimeError, match="must be called from async context"):
+            operation()

--- a/tricycle/_tree_var.py
+++ b/tricycle/_tree_var.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import attrs
+import contextvars
+import trio
+import weakref
+from contextlib import contextmanager
+from typing import TypeVar, Generic, Any, MutableMapping, cast, overload
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+__all__ = ["TreeVar", "TreeVarToken"]
+
+
+MISSING: Any = contextvars.Token.MISSING
+
+
+@attrs.define(eq=False)
+class _TreeVarState(Generic[T]):
+    """The value associated with the inner contextvar of a TreeVar."""
+
+    # Weakref to the task for which this state is valid; used to notice
+    # when a TreeVar has been inherited across start_soon() and recompute
+    # its value via tree-based inheritance.
+    task_ref: weakref.ref[trio.lowlevel.Task]
+
+    # Value accessed by TreeVar.get() and TreeVar.set() within that task.
+    value_for_task: T = MISSING
+
+    # Value that will be inherited by children of the given nursery within
+    # that task. Used to avoid having modifications after a nursery
+    # was opened affect child tasks of that nursery.
+    value_for_children: MutableMapping[trio.Nursery, T] = attrs.Factory(
+        weakref.WeakKeyDictionary
+    )
+
+    def save_current_for_children(self) -> None:
+        """Associate the current value_for_task as the value_for_children
+        of all this task's child nurseries that were not already being tracked.
+        Call this before modifying the value_for_task.
+        """
+        task = self.task_ref()
+        if task is None:  # pragma: no cover
+            return
+        for nursery in task.child_nurseries:
+            self.value_for_children.setdefault(nursery, self.value_for_task)
+
+
+@attrs.frozen
+class TreeVarToken(Generic[T]):
+    var: TreeVar[T]
+    old_value: T
+    _context: contextvars.Context = attrs.field(repr=False)
+
+
+class TreeVar(Generic[T]):
+    """A "tree variable": like a context variable except that its value
+    in a new task is inherited from the new task's parent nursery rather
+    than from the new task's spawner.
+
+    `TreeVar` objects support all the same methods and attributes as
+    `~contextvars.ContextVar` objects
+    (:meth:`~contextvars.ContextVar.get`,
+    :meth:`~contextvars.ContextVar.set`,
+    :meth:`~contextvars.ContextVar.reset`, and
+    `~contextvars.ContextVar.name`), and they are constructed the same
+    way. They also provide the additional methods :meth:`being` and
+    :meth:`get_in`, documented below.
+
+    Accessing or changing the value of a `TreeVar` outside of a Trio
+    task will raise `RuntimeError`. (Exception: :meth:`get_in` still
+    works outside of a task, as long as you have a reference to the
+    task or nursery of interest.)
+
+    .. note:: `TreeVar` values are not directly stored in the
+       `contextvars.Context`, so you can't use `Context.get()
+       <contextvars.Context.get>` to access them. If you need the value
+       in a context other than your own, use :meth:`get_in`.
+
+    """
+
+    __slots__ = ("_cvar", "_default")
+
+    _cvar: contextvars.ContextVar[_TreeVarState[T]]
+    _default: T
+
+    def __init__(self, name: str, *, default: T = MISSING):
+        self._cvar = contextvars.ContextVar(name)
+        self._default = default
+
+    def __repr__(self) -> str:
+        dflt = ""
+        if self._default is not MISSING:
+            dflt = f" default={self._default!r}"
+        return (
+            f"<tricycle.TreeVar name={self._cvar.name!r}{dflt} at {id(self._cvar):#x}>"
+        )
+
+    @property
+    def name(self) -> str:
+        return self._cvar.name
+
+    def _fetch(
+        self,
+        for_task: trio.lowlevel.Task,
+        current_task: Optional[trio.lowlevel.Task],
+    ) -> None:
+        """Return the _TreeVarState associated with *for_task*, inheriting
+        it from a parent nursery if necessary.
+        """
+        try:
+            current_state = for_task.context[self._cvar]
+            set_in_task = current_state.task_ref()
+        except KeyError:
+            set_in_task = None
+        if set_in_task is for_task:
+            return current_state
+
+        # This TreeVar hasn't yet been used in the current task.
+        # Initialize it based on the value it had when any of our
+        # enclosing nurseries were opened, nearest first.
+        nursery = for_task.eventual_parent_nursery or for_task.parent_nursery
+        inherited_value: T
+        if nursery is None:
+            inherited_value = MISSING
+        else:
+            parent_state = self._fetch(nursery.parent_task, current_task)
+            inherited_value = parent_state.value_for_children.get(
+                nursery, parent_state.value_for_task
+            )
+        new_state = _TreeVarState[T](weakref.ref(for_task), inherited_value)
+        if current_task is None:
+            # If no current_task was provided, then we're being called
+            # from get_in() and should not cache the intermediate
+            # values in case we're in a different thread where
+            # context.run() might fail.
+            pass
+        elif for_task.context is current_task.context:
+            self._cvar.set(new_state)
+        else:
+            for_task.context.run(self._cvar.set, new_state)
+        return new_state
+
+    @overload
+    def get(self) -> T:
+        ...
+
+    @overload
+    def get(self, default: U) -> Union[T, U]:
+        ...
+
+    def get(self, default: U = MISSING) -> Union[T, U]:
+        this_task = trio.lowlevel.current_task()
+        state = self._fetch(this_task, this_task)
+        if state.value_for_task is not MISSING:
+            return state.value_for_task
+        elif default is not MISSING:
+            return default
+        elif self._default is not MISSING:
+            return self._default
+        else:
+            raise LookupError(self)
+
+    def set(self, value: T) -> TreeVarToken[T]:
+        this_task = trio.lowlevel.current_task()
+        state = self._fetch(this_task, this_task)
+        state.save_current_for_children()
+        prev_value, state.value_for_task = state.value_for_task, value
+        return TreeVarToken(self, prev_value, this_task.context)
+
+    def reset(self, token: TreeVarToken[T]) -> None:
+        this_task = trio.lowlevel.current_task()
+        if token._context is not this_task.context:
+            raise ValueError(f"{token!r} was created in a different Context")
+        state = self._fetch(this_task, this_task)
+        state.save_current_for_children()
+        state.value_for_task = token.old_value
+
+    @contextmanager
+    def being(self, value: T) -> Iterator[None]:
+        """Returns a context manager which sets the value of this `TreeVar` to
+        *value* upon entry and restores its previous value upon exit.
+        """
+        token = self.set(value)
+        try:
+            yield
+        finally:
+            self.reset(token)
+
+    @overload
+    def get_in(
+        self, task_or_nursery: Union[trio.lowlevel.Task, trio.Nursery]
+    ) -> T:
+        ...
+
+    @overload
+    def get_in(
+        self, task_or_nursery: Union[trio.lowlevel.Task, trio.Nursery], default: U
+    ) -> Union[T, U]:
+        ...
+
+    def get_in(
+        self,
+        task_or_nursery: Union[trio.lowlevel.Task, trio.Nursery],
+        default: U = MISSING,
+    ) -> Union[T, U]:
+        """Gets the value of this `TreeVar` in the given
+        `~trio.lowlevel.Task` or `~trio.Nursery`.
+
+        The value in a task is the value that would be returned by a
+        call to :meth:`~contextvars.ContextVar.get` in that task. The
+        value in a nursery is the value that would be returned by
+        :meth:`~contextvars.ContextVar.get` at the beginning of a new
+        child task started in that nursery. The *default* argument has
+        the same semantics as it does for :meth:`~contextvars.ContextVar.get`.
+        """
+        if isinstance(task_or_nursery, trio.Nursery):
+            task = task_or_nursery.parent_task
+        else:
+            task = task_or_nursery
+        state = self._fetch(for_task=task, current_task=None)
+        if task is task_or_nursery:
+            result = state.value_for_task
+        else:
+            result = state.value_for_children.get(task_or_nursery, state.value_for_task)
+        if result is not MISSING:
+            return result
+        elif default is not MISSING:
+            return default
+        elif self._default is not MISSING:
+            return self._default
+        else:
+            raise LookupError(self)


### PR DESCRIPTION
A TreeVar acts like a context variable that is inherited at nursery creation time (and then by child tasks of that nursery) rather than at task creation time. They are useful for providing 'ambient' access to a resource that is tied to an `async with` block in the parent task, such as an open file or trio-asyncio event loop.

Prior art: https://github.com/python-trio/trio/pull/1543 (never made it into mainline Trio). The implementation without Trio core support is somewhat less efficient, but still workable.